### PR TITLE
Add CONTRIBUTE file, as Markdown text

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,12 @@
+---
+layout: web
+title: Alliance for Open Media Contributor License Agreements
+---
+
+Contributions to this project are accepted purusant to an executed Individual or
+Corporate Software Grant and Contributor License Agreement. The text of these
+agreements may be found at the following links:
+
+  * [Alliance for Open Media Software Grant and Corporate Contributor License Agreement](https://aomedia.org/license/software-grant-and-corporate-contributor-license-agreement/)
+
+  * [Alliance for Open Media Individual Contributor License Agreement ("Agreement") V2.0](https://aomedia.org/license/individual-contributor-license-agreement/)


### PR DESCRIPTION
Includes short intro text and links to individual and
corporate contributor agreements at aomedia.org.