### PR TITLE
Do not require previous DDs to parse current DD

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -821,6 +821,12 @@ extended_descriptor_fields() {
   if (template_dependency_structure_present_flag) {
     template_dependency_structure()
     active_decode_targets_bitmask = (1 << DtisCnt) - 1
+  } else if (active_decode_targets_present_flag || custom_dtis_flag || custom_chains_flag ) {
+    <b>dtis_cnt_minus_one</b> = f(5)
+    DtisCnt = dtis_cnt_minus_one + 1
+    if (custom_chains_flag) {
+      chains_cnt = ns(DtisCnt + 1)
+    }
   }
 
   if (active_decode_targets_present_flag) {

--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -825,7 +825,7 @@ extended_descriptor_fields() {
     <b>dtis_cnt_minus_one</b> = f(5)
     DtisCnt = dtis_cnt_minus_one + 1
     if (custom_chains_flag) {
-      chains_cnt = ns(DtisCnt + 1)
+      <b>chains_cnt</b> = ns(DtisCnt + 1)
     }
   }
 


### PR DESCRIPTION
As explained in AOMediaCodec#153 the DD from last iframe is required in order to know the `DtisCnt`  and `chains_cnt` required to parse properly the extension.

This PR adds those values in case they are needed, causing extra overhead in case that `active_decode_targets_present_flag` `custom_dtis_flag` or `custom_chains_flag` are set but no `template_dependency_structure_present_flag` is set.