### PR TITLE
Fix A.6.1 examples style

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -1131,7 +1131,7 @@ The URI for declaring this header extension in an extmap attribute is "https://a
 
 #### A.6.1 Scenarios
 
-#### A.6.1.1 Decode targets, Decode Target Indications, and Chains
+##### A.6.1.1 Decode targets, Decode Target Indications, and Chains
 In the following example, the concepts of Decode targets, Chains, and DTI are discussed in the context of the L2T3 scalability structure from the perspective of frame_number=5 (F5).
 
 ![L2T3](assets/images/L2T3.svg)
@@ -1188,7 +1188,7 @@ The DT2 client would track Chain0. From the DD received with F5, the client woul
 
 The DT3 client would track Chain1. From the DD received with F5, the client would detect that the last essential frame is F2. Thus it is not safe to start decoding F5. Due to the fact that frames must be decoded in decode order and F2 is essential for all HD frames, decoding F5 before F2 would prevent the decoding of F2 and all subsequent HD frames. The client therefore should wait for F2. The client may send a Generic NACK per [RFC4585] in order to notify the sender that packets have been missed since the receipt of F1, or may send a Layer Refresh Request (LRR) per [I-D.ietf-avtext-lrr] in order to refresh the media substream.
 
-#### A.6.1.2 Spatial Upswitch
+##### A.6.1.2 Spatial Upswitch
 In the following example, spatial upswitch is discussed in the context of the L2T1 scalability structure.
 
 ![L2T1](assets/images/L2T1.svg)

--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -1189,8 +1189,8 @@ The DT2 client would track Chain0. From the DD received with F5, the client woul
 The DT3 client would track Chain1. From the DD received with F5, the client would detect that the last essential frame is F2. Thus it is not safe to start decoding F5. Due to the fact that frames must be decoded in decode order and F2 is essential for all HD frames, decoding F5 before F2 would prevent the decoding of F2 and all subsequent HD frames. The client therefore should wait for F2. The client may send a Generic NACK per [RFC4585] in order to notify the sender that packets have been missed since the receipt of F1, or may send a Layer Refresh Request (LRR) per [I-D.ietf-avtext-lrr] in order to refresh the media substream.
 
 #### A.6.1.2 Spatial Upswitch
-
 In the following example, spatial upswitch is discussed in the context of the L2T1 scalability structure.
+
 ![L2T1](assets/images/L2T1.svg)
 L2T1
 {: .caption }


### PR DESCRIPTION
Fix minor formatting issues introduced with the A.6.1.2 Spatial Upswitch example:
-add an empty line after first sentence to avoid it getting style from {: .caption} annotation from the diagram
-make A.6.1.1 and A.6.1.2 subsections of the A.6.1 instead of having them at the same level