### PR TITLE
Delete inaccurate statement about integer fields in av1 rtp payload

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -85,7 +85,7 @@ Temporal and spatial scalability layers are associated with non-negative integer
 
 ## 4. Payload Format
 
-This section describes how the encoded AV1 bitstream is encapsulated in RTP. All integer fields in this specification are encoded as unsigned integers in network byte order.
+This section describes how the encoded AV1 bitstream is encapsulated in RTP.
 
 
 ### 4.1 RTP Header Usage


### PR DESCRIPTION
Section 4, RTP Payload format for av1 describes just 2 fields: aggregation header and OBU fragment size.
aggregation header is not an integer field,
and OBU fragment size is encoded using leb128 which is not the same as "unsigned integer in network byte order"