### PR TITLE
Restructure tables in the appendix

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -785,16 +785,6 @@ ns(n) {
 }
 </code></pre>
 
-| Symbol name               | Value | Description                                         |
-| ------------------------- | ----- | --------------------------------------------------- |
-| MAX_TEMPLATE_ID           | 63    | Maximum value for a frame_dependency_template_id to identify a template
-| MAX_SPATIAL_ID            | 3     | Maximum value for a FrameSpatialId
-| MAX_TEMPORAL_ID           | 7     | Maximum value for a FrameTemporalId
-{:.table .table-sm .table-bordered }
-
-Table A.1. Syntax constants
-{: .caption }
-
 <pre><code>
 dependency_descriptor( sz ) {
   TotalConsumedBits = 0
@@ -863,8 +853,7 @@ template_dependency_structure() {
 
 <pre><code>
 frame_dependency_definition() {
-  templateIndex = (frame_dependency_template_id + (MAX_TEMPLATE_ID + 1) -
-                   template_id_offset) % (MAX_TEMPLATE_ID + 1)
+  templateIndex = (frame_dependency_template_id + 64 - template_id_offset) % 64
   If (templateIndex >= TemplatesCnt) {
     return  // error
   }
@@ -936,7 +925,7 @@ render_resolutions() {
 template_dtis() {
   for (templateIndex = 0; templateIndex < TemplatesCnt; templateIndex++) {
     for (dtiIndex = 0; dtiIndex < DtisCnt; dtiIndex++) {
-      // See table A.2 below for meaning of DTI values.
+      // See table A.1 below for meaning of DTI values.
       <b>template_dti[templateIndex][dtiIndex]</b> = f(2)
     }
   }
@@ -946,7 +935,7 @@ template_dtis() {
 <pre><code>
 frame_dtis() {
   for (dtiIndex = 0; dtiIndex < DtisCnt; dtiIndex++) {
-    // See table A.2 below for meaning of DTI values.
+    // See table A.1 below for meaning of DTI values.
     <b>frame_dti[dtiIndex]</b> = f(2)
   }
 }
@@ -1051,7 +1040,7 @@ The semantics pertaining to the Dependency Descriptor syntax section above is de
 
 * **resolutions_present_flag**: indicates the presence of render_resolutions. When the resolutions_present_flag is set to 1, render_resolutions MUST be present; otherwise render_resolutions MUST NOT be present.
 
-* **next_layer_idc**: used to determine spatial ID and temporal ID for the next Frame dependency template. Table A.3 describes how the spatial ID and temporal ID values are determined. A next_layer_idc equal to 3 indicates that no more Frame dependency templates are present in the Frame dependency structure.
+* **next_layer_idc**: used to determine spatial ID and temporal ID for the next Frame dependency template. Table A.2 describes how the spatial ID and temporal ID values are determined. A next_layer_idc equal to 3 indicates that no more Frame dependency templates are present in the Frame dependency structure.
 
 * **max_render_width_minus_1[spatial_id]**: indicates the maximum render width minus 1 for frames with spatial ID equal to spatial_id.
 
@@ -1061,7 +1050,7 @@ The semantics pertaining to the Dependency Descriptor syntax section above is de
 
 * **decode_target_protected_by[dtIndex]**: the index of the Chain that protects the Decode target, dtIndex. When chains_cnt > 0, each Decode target MUST be protected by exactly one Chain.
 
-* **template_dti[templateIndex][]**: an array of size dtis_cnt_minus_one + 1 containing Decode Target Indications for the Frame dependency template having index value equal to templateIndex. Table A.2 contains a description of the Decode Target Indication values.
+* **template_dti[templateIndex][]**: an array of size dtis_cnt_minus_one + 1 containing Decode Target Indications for the Frame dependency template having index value equal to templateIndex. Table A.1 contains a description of the Decode Target Indication values.
 
 * **template_chain_fdiff[templateIndex][]**: an array of size chains_cnt containing chain-FDIFF values for the Frame dependency template having index value equal to templateIndex. In a template, the values of chain-FDIFF can be in the range 0 to 15, inclusive.
 
@@ -1069,15 +1058,15 @@ The semantics pertaining to the Dependency Descriptor syntax section above is de
 
 * **fdiff_minus_one**: the difference between frame_number and the frame_number of the Referred frame minus one. The calculation is done modulo the size of the frame_number field.
 
-| DTI                    | Value |                                                        |
-| ---------------------- | ----- | ------------------------------------------------------ |
-| Not present indication | 0     | No payload for this Decode target is present.
-| Discardable indication | 1     | Payload for this Decode target is present and discardable.
-| Switch indication      | 2     | Payload for this Decode target is present and switch is possible (Switch indication).
-| Required indication    | 3     | Payload for this Decode target is present but it is neither discardable nor is it a Switch indication.
+| DTI                    | Value | Symbol |                                                        |
+| ---------------------- | ----- | ------ | ------------------------------------------------------ |
+| Not present indication | 0     | -      | No payload for this Decode target is present.
+| Discardable indication | 1     | D      | Payload for this Decode target is present and discardable.
+| Switch indication      | 2     | S      | Payload for this Decode target is present and switch is possible (Switch indication).
+| Required indication    | 3     | R      | Payload for this Decode target is present but it is neither discardable nor is it a Switch indication.
 {:.table .table-sm .table-bordered }
 
-Table A.2. Decode Target Indication (DTI) values.
+Table A.1. Decode Target Indication (DTI) values.
 {: .caption }
 
 **Frame dependency defintion**
@@ -1096,7 +1085,7 @@ Table A.2. Decode Target Indication (DTI) values.
 | 3              | No more Frame dependency templates are present in the Frame dependency structure.
 {:.table .table-sm .table-bordered }
 
-Table A.3. Derivation Of Next Spatial ID And Temporal ID Values.
+Table A.2. Derivation Of Next Spatial ID And Temporal ID Values.
 {: .caption }
 
 
@@ -1325,7 +1314,7 @@ The first way uses fewer templates and therefore requires fewer bits in the firs
 
 #### A.6.2 Scalability structure examples
 
-Each example in this section contains a prediction structure figure and a table describing the associated Frame dependency structure. The Frame dependency structure table column headings have the meanings listed below. For the DTI- related columns, Table A.4 shows the symbol used to represent each DTI value.
+Each example in this section contains a prediction structure figure and a table describing the associated Frame dependency structure. The Frame dependency structure table column headings have the meanings listed below. For the DTI- related columns, Table A.1 shows the symbol used to represent each DTI value.
 
   * Idx - template index
   * S - spatial ID
@@ -1333,17 +1322,6 @@ Each example in this section contains a prediction structure figure and a table 
   * Fdiffs - comma delimited list of TemplateFdiff[Idx] values
   * Chain(s) - **template_chain_fdiff[Idx]** values for each Chain
   * DTI - **template_dti[Idx]**
-
-| DTI                    | Value | Symbol   |
-| ---------------------- | ----- | -------- |
-| Not present indication | 0     | -        |
-| Discardable indication | 1     | D        |
-| Switch indication      | 2     | S        |
-| Required indication    | 3     | R        |
-{:.table .table-sm .table-bordered }
-
-Table A.4. DTI values
-{: .caption }
 
 
 ##### A.6.2.1 L1T3 Single Spatial Layer with 3 Temporal Layers


### PR DESCRIPTION
Delete Table for syntax constants (to address issue#167)
  implicitly remove limitation for spatial and  temporal ids
  embed MAX_TEMPLATE_ID directly into syntax where it is used for modulo operation, not as a limitation.
Merge two Decode Target Indication tables into one
Re enumerate the tables.