### PR TITLE
fix email address for iana registration

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -349,7 +349,7 @@ This section specifies the parameters that MAY be used to select optional featur
   * None.
 * Person & email address to contact for further information:
   * Name: Alliance for Open Media
-  * Email: registrations@aomedia.org
+  * Email: registration@aomedia.org
 * Intended usage:
   * COMMON
 * Restrictions on usage:


### PR DESCRIPTION
change registrations@aomedia.org to registration@aomedia.org