### PR TITLE
editorial: make wording of missing parameters consistent

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -328,7 +328,7 @@ The **profile** parameter is an integer indicating the highest AV1 profile that 
 
 The **level-idx** parameter is an integer indicating the highest AV1 level that may have been used to generate the bitstream or that the receiver supports. The range of possible values is identical to the **seq_level_idx** syntax element specified in [AV1]. If the parameter is not present, it MUST be inferred to be 5 (level 3.1).
 
-The **tier** parameter is an integer indicating the highest tier that may have been used to generate the bitstream or that the receiver supports. The range of possible values is identical to the **seq_tier** syntax element specified in [AV1]. If the parameter is not present, the tier MUST be inferred to be 0.
+The **tier** parameter is an integer indicating the highest tier that may have been used to generate the bitstream or that the receiver supports. The range of possible values is identical to the **seq_tier** syntax element specified in [AV1]. If the parameter is not present, it MUST be inferred to be 0.
 
 #### 7.2.1 Mapping of Media Subtype Parameters to SDP
 The media type video/AV1 string is mapped to fields in the Session Description Protocol (SDP) per [RFC4566] as follows:


### PR DESCRIPTION
tier was the only of the three parameter that was spelled out.

(happy to do it the other way round too, I just value consistency ;-))