### PR TITLE
Clarify definition of the S-mode

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -54,7 +54,7 @@ Open Bitstream Unit (OBU)
 : The smallest bitstream data framing unit in AV1. All AV1 bitstream structures are packetized in OBUs.
 
 "S" Mode
-: A scalability mode in which multiple encodings are sent on the same SSRC. This includes the S2T1, S2T1h, S2T2, S2T2h, S2T3, S2T3h, S3T1, S3T1h, S3T2, S3T2h, S3T3 and S3T3h scalability modes defined in Section 6.7.5 of [AV1]. 
+: A scalability mode in which multiple independent encodings are sent on the same SSRC. This includes the S2T1, S2T1h, S2T2, S2T2h, S2T3, S2T3h, S3T1, S3T1h, S3T2, S3T2h, S3T3 and S3T3h scalability modes defined in Section 6.7.5 of [AV1]. 
 
 Selective Forwarding Middlebox (SFM)
 : A middlebox that relays streams among transmitting and receiving clients by selectively forwarding packets without accessing the media ([RFC7667]).


### PR DESCRIPTION
As discussed in the working group clarify "S" mode definition.

current definition can be misunderstood that "S" imply any "Scalability", but intended understand is that "S" imply simulcast-like scalability. 