### PR TITLE
Clarify sequence header aggregation with base layer

### DIFF
--- a/av1-rtp-spec.md
+++ b/av1-rtp-spec.md
@@ -261,7 +261,7 @@ If more than one OBU contained in an RTP packet has an OBU extension header, the
 
 If a sequence header OBU is present in an RTP packet, then it	SHOULD be the first OBU in the packet. OBUs that are not associated with a particular layer (and thus do not have an OBU extension header) SHOULD be in the beginning of a packet, following the sequence header OBU if present.
 
-A sequence header OBU SHOULD be included in the base layer when scalable encoding is used. When simulcast encodings are transported on the same SSRC (an "S" mode), a sequence header OBU SHOULD be aggregated with each spatial layer. This ensures that if an intermediary removes simulcast encodings from the bitstream before forwarding, the modified bitstream will still be decodable.
+A sequence header OBU SHOULD be aggregated with the base layer when scalable encoding is used. When simulcast encodings are transported on the same SSRC (an "S" mode), a sequence header OBU SHOULD be aggregated with each spatial layer. This ensures that if an intermediary removes simulcast encodings from the bitstream before forwarding, the modified bitstream will still be decodable.
 
 
 ### 5.1 Examples


### PR DESCRIPTION
As discussed in the working group,
clarify this paragraph is just about aggregation with other OBUs within an RTP packet and doesn't affect OBU content.

'included in' can be misinterpreted as sequence header should have OBU extension header specifying the base layer,
however that is not the intent.
